### PR TITLE
Add separate test-watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --coverage",
+    "test": "react-scripts test --coverage --watchAll=false",
+    "test-watch": "react-scripts test",
     "eject": "react-scripts eject",
     "prepare": "husky install",
     "format": "prettier --write .",


### PR DESCRIPTION
`test` will now _NOT_ watch the files, but will generate a coverage report. `test-watch` will watch the tests, but not generate a coverage report.